### PR TITLE
fix: Windows command startup and beta.2 packaging

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
           version: 11.19.0
       - uses: actions/setup-node@v4
         with:
-          node-version: 24.15.0
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,8 @@
 name: OpenClaw nightly compatibility
 
 on:
+  pull_request:
+    paths: ["src/**", "test/**", ".github/workflows/nightly.yml", "package.json", "pnpm-lock.yaml"]
   schedule:
     - cron: "23 3 * * *"
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           version: 11.19.0
       - uses: actions/setup-node@v4
         with:
-          node-version: 24.15.0
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - run: pnpm install --frozen-lockfile
@@ -28,7 +28,7 @@ jobs:
         shell: bash
         run: test "${GITHUB_REF_NAME#v}" = "$(node -p "require('./package.json').version")"
       - name: Publish beta
-        if: vars.NPM_TRUSTED_PUBLISHING_READY == 'true' && contains(github.ref_name, 'beta')
+        if: contains(github.ref_name, 'beta')
         shell: bash
         run: |
           package_name=$(node -p "require('./package.json').name")
@@ -39,7 +39,7 @@ jobs:
             npm publish --provenance --access public --tag next
           fi
       - name: Publish stable
-        if: vars.NPM_TRUSTED_PUBLISHING_READY == 'true' && !contains(github.ref_name, 'beta')
+        if: ${{ !contains(github.ref_name, 'beta') }}
         shell: bash
         run: |
           package_name=$(node -p "require('./package.json').name")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.0.0-beta.2
+
+- Fixed Windows npm-installed OpenClaw startup by invoking the installed JavaScript entry without a shell.
+- Added real Windows process tests, including paths with spaces and literal shell metacharacters.
+- Made failed nightly checks show redacted diagnostic output instead of `undefined`.
+- Run official stable-version compatibility checks on relevant pull requests before merging.
+- Include the current bilingual installation and release guidance in the npm package.
+
 ## 2.0.0-beta.1
 
 - Repositioned the project as OpenClaw Companion / OpenClaw 中文助手.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 [中文](#中文) · [English](#english)
 
+`2.0.0-beta.2` 修复 Windows npm 安装后的命令启动问题，并改进夜间测试的脱敏错误说明。Beta 用户继续使用 `@next` 获取已发布的修正版。
+
+`2.0.0-beta.2` fixes command startup after Windows npm installation and improves redacted nightly failure reports. Beta users can continue using `@next` for published fixes.
+
 > [!IMPORTANT]
 > **v2 发布状态：** `2.0.0-beta.1` 已发布到 npm，推荐明确使用 `openclaw-companion@next` 安装。正式版仍需完成至少 14 天 Beta 观察，并解决所有 P0/P1 安全或安装问题。
 >
@@ -57,6 +61,8 @@ OpenClaw 已经提供安装器、配置向导、Doctor、更新、备份和诊�
 - Windows 10/11、macOS 13+、Ubuntu 22.04/24.04 或 Debian 12。
 - Node.js 22.22.3+、24.15+、25.9+ 或 26；明确不支持 Node 23。
 - OpenClaw 2026.5.29 或更高版本；若缺失，兼容启动器会在确认后调用官方安装器。
+
+上述 Node 范围是 Companion 自身的兼容范围。OpenClaw 新版本可能要求更高版本；例如 OpenClaw 2026.9.3 要求 Node 24.16+（24 系列）或 26.1+。新安装建议使用当前 Node 24 LTS，由官方安装器检查具体要求。
 
 当前 Beta：
 
@@ -242,6 +248,8 @@ Requirements:
 - Windows 10/11, macOS 13+, Ubuntu 22.04/24.04, or Debian 12.
 - Node.js 22.22.3+, 24.15+, 25.9+, or 26; Node 23 is explicitly unsupported.
 - OpenClaw 2026.5.29 or newer. When it is missing, the compatibility launcher asks before invoking the official installer.
+
+The Node range above describes Companion itself. Newer OpenClaw releases can require newer Node versions; OpenClaw 2026.9.3 requires Node 24.16+ (24.x) or 26.1+. For new installs, use current Node 24 LTS and let the official installer check its requirements.
 
 Current Beta:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 [![CI](https://github.com/JFroson0610/openclaw-easy-deploy/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/JFroson0610/openclaw-easy-deploy/actions/workflows/ci.yml)
 [![npm beta](https://img.shields.io/npm/v/openclaw-companion/next?label=npm%20beta)](https://www.npmjs.com/package/openclaw-companion)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status: v2 beta](https://img.shields.io/badge/status-v2%20beta-blue.svg)](https://github.com/JFroson0610/openclaw-easy-deploy/releases/tag/v2.0.0-beta.1)
+[![Status: v2 beta](https://img.shields.io/badge/status-v2%20beta-blue.svg)](https://github.com/JFroson0610/openclaw-easy-deploy/releases)
+[![Upstream compatibility](https://github.com/JFroson0610/openclaw-easy-deploy/actions/workflows/nightly.yml/badge.svg?branch=main)](https://github.com/JFroson0610/openclaw-easy-deploy/actions/workflows/nightly.yml)
 [![Telemetry: none](https://img.shields.io/badge/telemetry-none-success.svg)](SECURITY.md)
 
 [中文](#中文) · [English](#english)
@@ -17,9 +18,9 @@
 `2.0.0-beta.2` fixes command startup after Windows npm installation and improves redacted nightly failure reports. Beta users can continue using `@next` for published fixes.
 
 > [!IMPORTANT]
-> **v2 发布状态：** `2.0.0-beta.1` 已发布到 npm，推荐明确使用 `openclaw-companion@next` 安装。正式版仍需完成至少 14 天 Beta 观察，并解决所有 P0/P1 安全或安装问题。
+> **v2 发布状态：** 已发布的 Beta 可通过 `openclaw-companion@next` 安装，具体版本见上方 npm 徽章。正式版仍需完成至少 14 天 Beta 观察，并解决所有 P0/P1 安全或安装问题。
 >
-> **v2 release status:** `2.0.0-beta.1` is available from npm. Install the explicit `openclaw-companion@next` tag. The stable release still requires at least 14 days of Beta observation and no unresolved P0/P1 security or installation issue.
+> **v2 release status:** Published betas are available through `openclaw-companion@next`; the npm badge above shows the published version. The stable release still requires at least 14 days of Beta observation and no unresolved P0/P1 security or installation issue.
 
 > [!WARNING]
 > 这是社区项目，并非 OpenClaw 官方产品。OpenClaw 名称、商标和上游代码归其各自权利人所有。

--- a/docs/installation-zh.md
+++ b/docs/installation-zh.md
@@ -1,6 +1,6 @@
 # OpenClaw Companion 中文安装指南
 
-> `openclaw-companion@2.0.0-beta.1` 已发布到 npm 的 `next` 渠道。正式版仍需完成至少 14 天 Beta 观察，并解决所有 P0/P1 安全或安装问题。
+> Beta 通过 npm 的 `next` 渠道发布，旧版一键链接也会安装此渠道的修正版。正式版仍需完成至少 14 天 Beta 观察，并解决所有 P0/P1 安全或安装问题。
 
 ## 前置条件
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -24,6 +24,17 @@ This checklist separates completed engineering work from owner-only publication 
 
 ## Beta observation
 
+### `2.0.0-beta.2` maintenance
+
+- [x] Fix npm-installed Windows OpenClaw startup without enabling a shell.
+- [x] Add Windows process regression tests and redacted nightly failure output.
+- [x] Include current bilingual README in the package.
+- [ ] Verify PR CI and official stable OpenClaw smoke checks on all three platforms.
+- [ ] Publish beta.2 to npm `next` and verify the registry package.
+- [ ] Create the matching GitHub prerelease.
+
+### Stable-release gates
+
 - [ ] Run Beta for at least 14 days.
 - [ ] Keep all required three-platform checks green.
 - [ ] Resolve every P0/P1 security or installation issue.

--- a/install.ps1
+++ b/install.ps1
@@ -8,7 +8,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 $OfficialInstaller = "https://openclaw.ai/install.ps1"
-$CompanionSpec = if ($env:OPENCLAW_COMPANION_SPEC) { $env:OPENCLAW_COMPANION_SPEC } else { "openclaw-companion@latest" }
+$CompanionSpec = if ($env:OPENCLAW_COMPANION_SPEC) { $env:OPENCLAW_COMPANION_SPEC } else { "openclaw-companion@next" }
 $OfficialRegistry = "https://registry.npmjs.org"
 $ChinaRegistry = "https://registry.npmmirror.com"
 

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 OFFICIAL_INSTALLER="https://openclaw.ai/install.sh"
-COMPANION_SPEC="${OPENCLAW_COMPANION_SPEC:-openclaw-companion@latest}"
+COMPANION_SPEC="${OPENCLAW_COMPANION_SPEC:-openclaw-companion@next}"
 OFFICIAL_REGISTRY="https://registry.npmjs.org"
 CHINA_REGISTRY="https://registry.npmmirror.com"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-companion",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Bilingual, China-friendly operations companion for OpenClaw",
   "type": "module",
   "bin": {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,15 +1,46 @@
 import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
 import type { CommandResult, CommandRunner, RunOptions } from "./types.js";
+
+// npm's Windows .cmd shim cannot be spawned without a shell. Run the
+// installed package's JavaScript entry directly so arguments stay literal.
+export function windowsOpenClawEntry(env: NodeJS.ProcessEnv): string | undefined {
+  const searchPath = Object.entries(env).find(([key]) => key.toLowerCase() === "path")?.[1] ?? "";
+  for (const item of searchPath.split(";")) {
+    const directory = item.replace(/^"|"$/g, "");
+    if (!directory) continue;
+    if (existsSync(path.join(directory, "openclaw.exe"))) return undefined;
+    if (!existsSync(path.join(directory, "openclaw.cmd"))) continue;
+    const root = path.join(directory, "node_modules", "openclaw");
+    try {
+      const manifest = JSON.parse(readFileSync(path.join(root, "package.json"), "utf8"));
+      const bin = typeof manifest.bin === "string" ? manifest.bin : manifest.bin?.openclaw;
+      if (manifest.name !== "openclaw" || typeof bin !== "string") return undefined;
+      const entry = path.resolve(root, bin);
+      const relative = path.relative(root, entry);
+      if (relative.startsWith("..") || path.isAbsolute(relative) || !/\.[cm]?js$/i.test(entry)) return undefined;
+      return existsSync(entry) ? entry : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
 
 export class NodeCommandRunner implements CommandRunner {
   hadSpawnFailure = false;
 
   async run(command: string, args: string[], options: RunOptions = {}): Promise<CommandResult> {
+    const env = { ...process.env, ...options.env };
+    const entry = process.platform === "win32" && command === "openclaw" ? windowsOpenClawEntry(env) : undefined;
+    const executable = entry ? process.execPath : command;
+    const executableArgs = entry ? [entry, ...args] : args;
     if (options.interactive) {
       return await new Promise((resolve) => {
-        const child = spawn(command, args, {
+        const child = spawn(executable, executableArgs, {
           stdio: "inherit",
-          env: { ...process.env, ...options.env },
+          env,
           shell: false,
         });
         child.once("error", (error) => {
@@ -21,9 +52,9 @@ export class NodeCommandRunner implements CommandRunner {
     }
 
     return await new Promise((resolve) => {
-      const child = spawn(command, args, {
+      const child = spawn(executable, executableArgs, {
         stdio: ["ignore", "pipe", "pipe"],
-        env: { ...process.env, ...options.env },
+        env,
         shell: false,
       });
       let stdout = "";

--- a/test/bootstrap.ps1
+++ b/test/bootstrap.ps1
@@ -14,7 +14,7 @@ try {
     $previousPath = $env:PATH
     $env:PATH = "$mockBin;$previousPath"
     $env:MOCK_LOG = $mockLog
-    $env:OPENCLAW_COMPANION_SPEC = "openclaw-companion@next"
+    $env:OPENCLAW_COMPANION_SPEC = ""
 
     & (Join-Path $PSScriptRoot "..\install.ps1") -Lang en | Out-Null
     $commands = Get-Content $mockLog -Raw

--- a/test/bootstrap.sh
+++ b/test/bootstrap.sh
@@ -20,7 +20,7 @@ ln -s mock-command "$mock_bin/npm"
 ln -s mock-command "$mock_bin/openclaw-companion"
 ln -s mock-command "$mock_bin/npx"
 
-PATH="$mock_bin:$PATH" MOCK_LOG="$mock_log" OPENCLAW_COMPANION_SPEC="openclaw-companion@next" \
+PATH="$mock_bin:$PATH" MOCK_LOG="$mock_log" OPENCLAW_COMPANION_SPEC="" \
   bash ./install.sh --lang en >/dev/null
 
 grep -F "npm ping --registry https://registry.npmjs.org" "$mock_log" >/dev/null

--- a/test/nightly-smoke.js
+++ b/test/nightly-smoke.js
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { redact } from "../dist/redact.js";
 
 const result = spawnSync(process.execPath, ["dist/cli.js", "check", "--json", "--deep"], {
   encoding: "utf8",
@@ -6,7 +7,8 @@ const result = spawnSync(process.execPath, ["dist/cli.js", "check", "--json", "-
 });
 
 if (result.status === 2 || result.error) {
-  console.error(result.stderr || result.error);
+  console.error(`Companion could not complete checks (exit=${result.status}, signal=${result.signal}).`);
+  console.error(redact([result.stdout, result.stderr, result.error?.message].filter(Boolean).join("\n")));
   process.exit(1);
 }
 
@@ -14,12 +16,12 @@ let payload;
 try {
   payload = JSON.parse(result.stdout);
 } catch {
-  console.error("Companion did not emit JSON", result.stdout, result.stderr);
+  console.error("Companion did not emit JSON", redact(`${result.stdout}\n${result.stderr}`));
   process.exit(1);
 }
 
 if (payload.schemaVersion !== 1 || !Array.isArray(payload.checks)) {
-  console.error("Unexpected check schema", payload);
+  console.error("Unexpected check schema", redact(JSON.stringify(payload)));
   process.exit(1);
 }
 

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { NodeCommandRunner, windowsOpenClawEntry } from "../dist/runner.js";
+
+function fixture(t) {
+  const directory = mkdtempSync(path.join(tmpdir(), "companion path & spaces-"));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const root = path.join(directory, "node_modules", "openclaw");
+  mkdirSync(root, { recursive: true });
+  writeFileSync(path.join(directory, "openclaw.cmd"), "@echo off\r\nexit /b 99\r\n");
+  writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "openclaw", bin: { openclaw: "openclaw.mjs" } }));
+  writeFileSync(path.join(root, "openclaw.mjs"), "console.log(JSON.stringify(process.argv.slice(2))); process.exit(Number(process.env.TEST_EXIT || 0));");
+  return { directory, root, entry: path.join(root, "openclaw.mjs") };
+}
+
+test("resolves npm Windows entry without interpreting the command shim", (t) => {
+  const f = fixture(t);
+  assert.equal(windowsOpenClawEntry({ Path: `"${f.directory}"` }), f.entry);
+  writeFileSync(path.join(f.root, "package.json"), JSON.stringify({ name: "openclaw", bin: "../../outside.mjs" }));
+  assert.equal(windowsOpenClawEntry({ PATH: f.directory }), undefined);
+});
+
+test("Windows runner preserves arguments, paths with spaces, and exit codes", { skip: process.platform !== "win32" }, async (t) => {
+  const f = fixture(t);
+  const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => key.toLowerCase() !== "path"));
+  env.Path = f.directory;
+  // Remove the original PATH spelling before running the actual child process.
+  const oldPathEntries = Object.entries(process.env).filter(([key]) => key.toLowerCase() === "path");
+  for (const [key] of oldPathEntries) delete process.env[key];
+  t.after(() => { for (const [key, value] of oldPathEntries) process.env[key] = value; });
+  const args = ["space value", "& echo INJECTED", "%COMSPEC%", "$(whoami)", 'quote"value'];
+  const runner = new NodeCommandRunner();
+  const result = await runner.run("openclaw", args, { env: { ...env, TEST_EXIT: "7" } });
+  assert.equal(result.exitCode, 7);
+  assert.deepEqual(JSON.parse(result.stdout), args);
+  assert.equal(runner.hadSpawnFailure, false);
+  const interactive = await runner.run("openclaw", [], { interactive: true, env: { ...env, TEST_EXIT: "9" } });
+  assert.equal(interactive.exitCode, 9);
+});
+
+test("runner reports an unavailable executable", async () => {
+  const runner = new NodeCommandRunner();
+  const result = await runner.run("companion-nonexistent-executable-238491", []);
+  assert.equal(result.exitCode, 2);
+  assert.equal(runner.hadSpawnFailure, true);
+  assert.ok(result.stderr.length > 0);
+});


### PR DESCRIPTION
Windows npm installs expose an openclaw.cmd shim, which the shell-free runner cannot execute. Resolve the installed package entry and launch it with Node, preserving literal arguments and exit codes for captured and interactive commands.

Adds real Windows process regression coverage, redacted nightly failure diagnostics, and upstream smoke checks on relevant PRs. Bumps to beta.2 so the updated bilingual README can ship in npm.

Validation: local typecheck, build, 22 passing tests (Windows-only test runs in CI), Markdown lint. Cross-platform CI and real stable OpenClaw smoke checks must pass before merge. Stable v2.0.0 remains subject to the beta observation gate.