### PR TITLE
release: OpenClaw Companion v2.0.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.0
+
+- Promote the verified beta.2 functionality to the stable channel at the owner's request, without a mandatory observation period.
+- Switch both legacy installers and bilingual installation instructions to npm `latest`.
+- Retain Windows, macOS, Linux, Node compatibility, backup safeguards, redaction, and automated upstream checks.
+- Publish through GitHub Trusted Publishing with provenance.
+
 ## 2.0.0-beta.2
 
 - Fixed Windows npm-installed OpenClaw startup by invoking the installed JavaScript entry without a shell.

--- a/README.md
+++ b/README.md
@@ -5,22 +5,17 @@
 > A bilingual operations companion that safely orchestrates official OpenClaw setup, checks, upgrades, backups, repairs, and diagnostics.
 
 [![CI](https://github.com/JFroson0610/openclaw-easy-deploy/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/JFroson0610/openclaw-easy-deploy/actions/workflows/ci.yml)
-[![npm beta](https://img.shields.io/npm/v/openclaw-companion/next?label=npm%20beta)](https://www.npmjs.com/package/openclaw-companion)
+[![npm](https://img.shields.io/npm/v/openclaw-companion)](https://www.npmjs.com/package/openclaw-companion)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Status: v2 beta](https://img.shields.io/badge/status-v2%20beta-blue.svg)](https://github.com/JFroson0610/openclaw-easy-deploy/releases)
+[![Status: v2 stable](https://img.shields.io/badge/status-v2%20stable-green.svg)](https://github.com/JFroson0610/openclaw-easy-deploy/releases)
 [![Upstream compatibility](https://github.com/JFroson0610/openclaw-easy-deploy/actions/workflows/nightly.yml/badge.svg?branch=main)](https://github.com/JFroson0610/openclaw-easy-deploy/actions/workflows/nightly.yml)
 [![Telemetry: none](https://img.shields.io/badge/telemetry-none-success.svg)](SECURITY.md)
 
 [中文](#中文) · [English](#english)
 
-`2.0.0-beta.2` 修复 Windows npm 安装后的命令启动问题，并改进夜间测试的脱敏错误说明。Beta 用户继续使用 `@next` 获取已发布的修正版。
+v2.0.0 正式版：中英双语操作流程、Windows 启动修复、验证备份和本地脱敏诊断。安装或从 Beta 升级请使用 `npm install -g openclaw-companion@latest`。
 
-`2.0.0-beta.2` fixes command startup after Windows npm installation and improves redacted nightly failure reports. Beta users can continue using `@next` for published fixes.
-
-> [!IMPORTANT]
-> **v2 发布状态：** 已发布的 Beta 可通过 `openclaw-companion@next` 安装，具体版本见上方 npm 徽章。正式版仍需完成至少 14 天 Beta 观察，并解决所有 P0/P1 安全或安装问题。
->
-> **v2 release status:** Published betas are available through `openclaw-companion@next`; the npm badge above shows the published version. The stable release still requires at least 14 days of Beta observation and no unresolved P0/P1 security or installation issue.
+v2.0.0 stable: bilingual workflows, Windows startup fixes, verified backups, and local sanitized diagnostics. Install or upgrade from beta with `npm install -g openclaw-companion@latest`.
 
 > [!WARNING]
 > 这是社区项目，并非 OpenClaw 官方产品。OpenClaw 名称、商标和上游代码归其各自权利人所有。
@@ -65,14 +60,7 @@ OpenClaw 已经提供安装器、配置向导、Doctor、更新、备份和诊�
 
 上述 Node 范围是 Companion 自身的兼容范围。OpenClaw 新版本可能要求更高版本；例如 OpenClaw 2026.9.3 要求 Node 24.16+（24 系列）或 26.1+。新安装建议使用当前 Node 24 LTS，由官方安装器检查具体要求。
 
-当前 Beta：
-
-```bash
-npm install -g openclaw-companion@next
-openclaw-companion setup --lang zh-CN
-```
-
-npm 会为全新包的首次发布自动建立 `latest` 标签，因此不带标签目前也会得到这个 Beta。为清楚表达用途并方便未来切换，测试用户请始终显式使用 `@next`。正式版完成观察期后才会正式推广无标签安装：
+安装正式版（Beta 用户也使用同一命令升级）：
 
 ```bash
 npm install -g openclaw-companion
@@ -252,14 +240,7 @@ Requirements:
 
 The Node range above describes Companion itself. Newer OpenClaw releases can require newer Node versions; OpenClaw 2026.9.3 requires Node 24.16+ (24.x) or 26.1+. For new installs, use current Node 24 LTS and let the official installer check its requirements.
 
-Current Beta:
-
-```bash
-npm install -g openclaw-companion@next
-openclaw-companion setup
-```
-
-The npm registry automatically creates a `latest` tag for the first release of a new package, so an untagged install currently resolves to this Beta as well. Testers should explicitly use `@next` to make their intent clear and ease the later transition. Untagged installation will be promoted only after the stable-release gate is complete:
+Install the stable release (beta users can upgrade with the same command):
 
 ```bash
 npm install -g openclaw-companion

--- a/docs/installation-zh.md
+++ b/docs/installation-zh.md
@@ -1,6 +1,6 @@
 # OpenClaw Companion 中文安装指南
 
-> Beta 通过 npm 的 `next` 渠道发布，旧版一键链接也会安装此渠道的修正版。正式版仍需完成至少 14 天 Beta 观察，并解决所有 P0/P1 安全或安装问题。
+> v2.0.0 正式版使用 npm 的 `latest` 渠道，旧版一键链接也安装正式版。
 
 ## 前置条件
 
@@ -8,14 +8,14 @@
 - 已安装官方 OpenClaw；若未安装，兼容启动器会在确认后调用官方安装器。
 - Node.js 版本需符合 OpenClaw 官方要求。
 
-## 当前 Beta 推荐安装
+## 安装正式版
 
 ```bash
-npm install -g openclaw-companion@next
+npm install -g openclaw-companion@latest
 openclaw-companion setup --lang zh-CN
 ```
 
-npm 会为全新包的首次发布自动建立 `latest` 标签，因此不带标签目前也会安装这个 Beta。测试用户仍应明确使用 `@next`；正式版完成观察期后才推广无标签安装。
+已安装 Beta 的用户运行上面的安装命令即可升级；OpenClaw 配置和认证仍由官方管理。
 
 如需从源码验证，请克隆仓库，运行 `pnpm install --frozen-lockfile && pnpm build`，再使用 `node dist/cli.js`。
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -35,14 +35,11 @@ This checklist separates completed engineering work from owner-only publication 
 
 Released 2026-09-09: [PR #8](https://github.com/JFroson0610/openclaw-easy-deploy/pull/8), [CI](https://github.com/JFroson0610/openclaw-easy-deploy/actions/runs/34358625531), [three-platform upstream checks](https://github.com/JFroson0610/openclaw-easy-deploy/actions/runs/34357819471), [OIDC publication](https://github.com/JFroson0610/openclaw-easy-deploy/actions/runs/34358965287), and [beta.2 release](https://github.com/JFroson0610/openclaw-easy-deploy/releases/tag/v2.0.0-beta.2).
 
-The npm `next` tag points to beta.2. The historical `latest` tag still points to beta.1 until stable promotion; documented Beta commands and both legacy launchers explicitly select `next`.
+At the beta.2 release, `next` pointed to beta.2 and `latest` still pointed to beta.1. Stable v2.0.0 moves the recommended installation and both legacy launchers to `latest`.
 
 ### Stable-release gates
 
-- [ ] Run Beta for at least 14 days.
-- [ ] Keep all required three-platform checks green.
-- [ ] Resolve every P0/P1 security or installation issue.
-- [ ] Review npm downloads, Stars/Forks, platform issues, external contributors, CI pass rate, and severe-issue repair time without adding telemetry.
+The owner explicitly waived the 14-day observation period and requested stable release. This is a release-policy decision, not a claim that 14 days of observation occurred. Release checks and the existing safety rules remain in place. Growth metrics are optional maintenance information, not a release gate.
 
 ## `v2.0.0`
 

--- a/install.ps1
+++ b/install.ps1
@@ -8,7 +8,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 $OfficialInstaller = "https://openclaw.ai/install.ps1"
-$CompanionSpec = if ($env:OPENCLAW_COMPANION_SPEC) { $env:OPENCLAW_COMPANION_SPEC } else { "openclaw-companion@next" }
+$CompanionSpec = if ($env:OPENCLAW_COMPANION_SPEC) { $env:OPENCLAW_COMPANION_SPEC } else { "openclaw-companion@latest" }
 $OfficialRegistry = "https://registry.npmjs.org"
 $ChinaRegistry = "https://registry.npmmirror.com"
 

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 OFFICIAL_INSTALLER="https://openclaw.ai/install.sh"
-COMPANION_SPEC="${OPENCLAW_COMPANION_SPEC:-openclaw-companion@next}"
+COMPANION_SPEC="${OPENCLAW_COMPANION_SPEC:-openclaw-companion@latest}"
 OFFICIAL_REGISTRY="https://registry.npmjs.org"
 CHINA_REGISTRY="https://registry.npmmirror.com"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-companion",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0",
   "description": "Bilingual, China-friendly operations companion for OpenClaw",
   "type": "module",
   "bin": {

--- a/test/bootstrap.ps1
+++ b/test/bootstrap.ps1
@@ -19,7 +19,7 @@ try {
     & (Join-Path $PSScriptRoot "..\install.ps1") -Lang en | Out-Null
     $commands = Get-Content $mockLog -Raw
     if ($commands -notmatch [regex]::Escape("npm ping --registry https://registry.npmjs.org")) { throw "npm ping was not called" }
-    if ($commands -notmatch [regex]::Escape("npm install -g openclaw-companion@next")) { throw "npm install was not called" }
+    if ($commands -notmatch [regex]::Escape("npm install -g openclaw-companion@latest")) { throw "npm install was not called" }
     if ($commands -notmatch [regex]::Escape("openclaw-companion setup --lang en")) { throw "Companion setup was not launched" }
     if ($commands -match "npm config set") { throw "bootstrap persisted npm configuration" }
 

--- a/test/bootstrap.sh
+++ b/test/bootstrap.sh
@@ -24,7 +24,7 @@ PATH="$mock_bin:$PATH" MOCK_LOG="$mock_log" OPENCLAW_COMPANION_SPEC="" \
   bash ./install.sh --lang en >/dev/null
 
 grep -F "npm ping --registry https://registry.npmjs.org" "$mock_log" >/dev/null
-grep -F "npm install -g openclaw-companion@next" "$mock_log" >/dev/null
+grep -F "npm install -g openclaw-companion@latest" "$mock_log" >/dev/null
 grep -F "openclaw-companion setup --lang en" "$mock_log" >/dev/null
 if grep -F "npm config set" "$mock_log" >/dev/null; then
   echo "bootstrap persisted npm configuration" >&2


### PR DESCRIPTION
Promote the tested beta.2 implementation to stable v2.0.0. Both legacy installers now select npm latest; bilingual README and installation guidance explain installation and migration from beta.

The owner explicitly waived the observation-period policy. Runtime safety rules are unchanged. No new runtime features are introduced.

Validation: typecheck, build, unit tests, documentation lint, dependency audit, bootstrap regression tests, platform CI, and official upstream compatibility checks.